### PR TITLE
Changing the gitattributes for the languges issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+*.sql linguist-language=SQL


### PR DESCRIPTION
This pull request makes a minor configuration update to the `.gitattributes` file to improve language detection for SQL files in the repository.

- Added a rule to explicitly set the linguist language for all `.sql` files to SQL, ensuring correct syntax highlighting and statistics in GitHub.